### PR TITLE
Get rid of postrecoveryboot/usbid_init [3/3]

### DIFF
--- a/config/init.recovery.st-ericsson.rc
+++ b/config/init.recovery.st-ericsson.rc
@@ -1,6 +1,7 @@
 on early-boot
     write /sys/class/android_usb/android0/idVendor 0fce
     write /sys/class/android_usb/android0/idProduct 5171
+    copy /sys/devices/platform/ab8500-i2c.0/ab8500-usb.0/boot_time_device /sys/devices/platform/ab8500-i2c.0/ab8500-usb.0/boot_time_device
 
 on property:sys.storage.ums_enabled=1
     write /sys/class/android_usb/android0/idVendor 0fce


### PR DESCRIPTION
Change-Id: I4bf5555a699a9fd05f1116da321609f3bb9aca41
